### PR TITLE
#52 Name toegevoegd aan details voor auto close

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,7 +64,7 @@
 <h1 class="animation-fade-in" style="--delay: 0.25s">Kalender</h1>
 
 {#each months as month, i}
-  <details class="animation-fade-in--down" style="--delay: {i * 0.05}s">
+  <details class="animation-fade-in--down" style="--delay: {i * 0.05}s" name=months>
     <summary>{month}</summary>
     <ol>
       {#each membersByMonth[i] as member}


### PR DESCRIPTION
## What does this change?

Resolves issue #52

Ik heb een detail name atributte toegevoegd zodat de details automatisch wordt gesloten als een andere wordt geopend. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

https://github.com/user-attachments/assets/5ed6e13f-25c4-44d9-bc06-64e2b0fe86bf


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

- Is er een betere manier om dit te doen?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->