### PR TITLE
#46 teveel witruimte namen en datums in details mobile 

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -153,6 +153,7 @@
 
   ol {
     list-style: none;
+    padding: 0;
   }
 
   .members-birthday {


### PR DESCRIPTION
## What does this change?

heb padding 0 toegevoegd aan de `<ol>`

Resolves issue #46 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images
<img width="204" height="206" alt="Scherm­afbeelding 2025-09-10 om 21 00 04" src="https://github.com/user-attachments/assets/9378522c-f40b-4ae7-9296-c96467a806d6" />

het lijntje om de maand zit er niet bij kwam omdat ik een foto wilde maken

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

- vinden jullie het zo goed staan. 
- kan het op een beter manier 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->