### PR TITLE
Overzichtspagina summery volgens design

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -112,14 +112,14 @@
     interpolate-size: allow-keywords;
   }
 
-    h1 {
-        display: flex;
-        justify-content: center;
-        font-size: 2.6rem;
-        font-family: var(--primary-font-family);
-    }
+  h1 {
+    display: flex;
+    justify-content: center;
+    font-size: 2.6rem;
+    font-family: var(--primary-font-family);
+  }
 
- .intro-text {
+  .intro-text {
     text-align: center;
     font-family: var(--secondary-font-family);
     font-weight: 100;


### PR DESCRIPTION
## What does this change?

Resolves issue #67 

Ik heb de overzichtspagina kwa styling meer volgens het design gemaakt. Hij is ook responsive op meerdere scherm breedtes. Ik heb btw ook de achtergrond kleur van de `body` aangepast. Ik vond de overgang van de groene overzichtspagina naar de roze detail page nogal heftig 🥸
 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

https://github.com/user-attachments/assets/ab1264d1-e992-412b-a5d9-a0f194245f2c


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review
- Moet ik nog dingen aanpassen? 
- Is hij goed zo?
- Is de code goed? 
- Dingen die ik niet genoemd heb?
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->