### PR TITLE
feat: change directus urls to serve images in webp #86

### DIFF
--- a/src/lib/components/Member.svelte
+++ b/src/lib/components/Member.svelte
@@ -16,7 +16,7 @@
             <img
                 class="member-mugshot"
                 src={member.mugshot
-                    ? `https://fdnd.directus.app/assets/${member.mugshot}?width=300&height=300`
+                    ? `https://fdnd.directus.app/assets/${member.mugshot}?width=300&height=300&format=webp`
                     : "https://wallpapers.com/images/high/funny-profile-picture-ylwnnorvmvk2lna0.webp"}
                 alt={member.name}
             />

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -24,7 +24,7 @@
   <div class="img-container">
     <img
       src={member.mugshot
-        ? `https://fdnd.directus.app/assets/${member.mugshot}?width=500&height=400`
+        ? `https://fdnd.directus.app/assets/${member.mugshot}?width=500&height=400&format=webp`
         : "https://wallpapers.com/images/high/funny-profile-picture-ylwnnorvmvk2lna0.webp"}
       alt={member.name}
     />


### PR DESCRIPTION
## What does this change?

Resolves issue #86. Voegt "&format=webp" toe aan de twee plekken waar we images opvragen; de overzichtspagina en de detailpagina.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

Ik heb in de browser getest of de afbeeldingen daadwerkelijk als webP weergegeven werden.

## How to review

- Klopt het dat we maar op twee plekken images opvragen?
- Worden de afbeeldingen in jouw browser ook als webP weergegeven?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->