### PR TITLE
89 dark mode improvements

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -91,9 +91,9 @@
       --primary-color: #ffffff;
       --secondary-color: #000000;
       --bg-general: #c2ecc0;
-      --bg-color-1: #dac1e4;
-      --bg-color-2: #c1d1e4;
-      --bg-color-3: #fae3b8;
+      --bg-color-1: #503c7b;
+      --bg-color-2: #512b59;
+      --bg-color-3: #3A2B59;
       --error-color: #ff7171;
       --primary-text: #ffffff;
       --secondary-text: #000000;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -136,12 +136,14 @@
     justify-content: center;
     font-size: 2.6rem;
     font-family: var(--primary-font-family);
+    color: var(--primary-text);
   }
 
   .intro-text {
     text-align: center;
     font-family: var(--secondary-font-family);
     font-weight: 100;
+    color: var(--primary-text);
     line-height: 1.3;
     font-size: 1.4rem;
     max-width: 30em;

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -79,6 +79,15 @@
     color: var(--primary-text);
   }
 
+  a {
+    font-family: var(--secondary-font-family);
+    color: var(--primary-text);
+  }
+
+  a:visited {
+    color: var(--primary-text);
+  }
+
   .profile-container {
     display: flex;
     flex-direction: column;

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -10,7 +10,7 @@
 
   <style>
     body {
-      background-color: #dac1e4;
+      background-color: var(--bg-color-1);
       margin: 1rem 2rem;
       min-height: 100vh;
       font-family: Arial, Helvetica, sans-serif;
@@ -76,6 +76,7 @@
       "Lucida Sans Unicode", Geneva, Verdana, sans-serif;
     text-align: center;
     margin: 1rem 0;
+    color: var(--primary-text);
   }
 
   .profile-container {


### PR DESCRIPTION
## What does this change?

Resolves issue #89. Voegt nieuwe waardes toe aan bg1, bg2 en bg3 onder de dark mode media query. Vervangt waardes door custom variables waar dat nog nodig was, zodat alles netjes meeverandert in dark mode. Stijlt het 'terug naar overzicht' linkje. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

Ik heb in de browser getest of alles nu leesbaar is in dark mode.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Voor:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/f6fa1694-91d0-4dc7-96f4-fdde7102b325" />
Na:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/d37743af-e249-4fe3-b96d-b857b42f4a1e" />


## How to review

Check in de browser of alles er goed uit ziet.
Zijn de kleuren die ik heb gekozen voor de achtergrond oké?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->